### PR TITLE
Add image url link

### DIFF
--- a/src/phpscraper.php
+++ b/src/phpscraper.php
@@ -834,11 +834,13 @@ class core
             $linkObj = new \Symfony\Component\DomCrawler\Link($link, $this->currentURL());
 
             // Check if the anchor is maybe only an image.
-            // If so wrap it into DomCrawler\Image to get the Uri
-            // $image = (trim($link->nodeValue) !== '' || !isset($link->childNodes[1]) || $link->childNodes[1]->nodeName !== 'img') ? null :  null;
-            // (new \Symfony\Component\DomCrawler\Image($link->childNodes[1], $this->currentURL()))->getUri();
-            $image = null;
-            // 'image' => $image,
+            $image = [];
+            foreach($link->childNodes as $childNode) {
+                if (!empty($childNode) && $childNode->nodeName === 'img') {
+                    $image[] = (new \Symfony\Component\DomCrawler\Image($childNode, $this->currentURL()))->getUri();
+                }
+            }
+
             // Collect commonly interesting attributes and URL
             $entry = [
                 'url' => $linkObj->getUri(),
@@ -846,6 +848,7 @@ class core
                 'title' => $link->getAttribute('title') == '' ? null : $link->getAttribute('title'),
                 'target' => $link->getAttribute('target') == '' ? null : $link->getAttribute('target'),
                 'rel' => $link->getAttribute('rel') == '' ? null : strtolower($link->getAttribute('rel')),
+                'image' => $image,
             ];
 
             // Add additional parameters in for "rel"

--- a/tests/LinkTest.php
+++ b/tests/LinkTest.php
@@ -50,6 +50,7 @@ class LinkTest extends BaseTest
                 'title' => null,
                 'target' => '_blank',
                 'rel' => null,
+                'image' => [],
                 'isNofollow' => false,
                 'isUGC' => false,
                 'isSponsored' => false,
@@ -62,6 +63,7 @@ class LinkTest extends BaseTest
                 'title' => null,
                 'target' => '_blank',
                 'rel' => null,
+                'image' => [],
                 'isNofollow' => false,
                 'isUGC' => false,
                 'isSponsored' => false,
@@ -74,6 +76,7 @@ class LinkTest extends BaseTest
                 'title' => null,
                 'target' => '_blank',
                 'rel' => null,
+                'image' => [],
                 'isNofollow' => false,
                 'isUGC' => false,
                 'isSponsored' => false,
@@ -86,6 +89,7 @@ class LinkTest extends BaseTest
                 'title' => null,
                 'target' => 'kitten',
                 'rel' => null,
+                'image' => [],
                 'isNofollow' => false,
                 'isUGC' => false,
                 'isSponsored' => false,
@@ -98,6 +102,7 @@ class LinkTest extends BaseTest
                 'title' => null,
                 'target' => 'kitten',
                 'rel' => null,
+                'image' => [],
                 'isNofollow' => false,
                 'isUGC' => false,
                 'isSponsored' => false,
@@ -110,6 +115,7 @@ class LinkTest extends BaseTest
                 'title' => null,
                 'target' => 'kitten',
                 'rel' => null,
+                'image' => [],
                 'isNofollow' => false,
                 'isUGC' => false,
                 'isSponsored' => false,
@@ -151,6 +157,7 @@ class LinkTest extends BaseTest
                 'title' => null,
                 'target' => null,
                 'rel' => 'nofollow',
+                'image' => [],
                 'isNofollow' => true,
                 'isUGC' => false,
                 'isSponsored' => false,
@@ -163,6 +170,7 @@ class LinkTest extends BaseTest
                 'title' => null,
                 'target' => null,
                 'rel' => 'ugc',
+                'image' => [],
                 'isNofollow' => false,
                 'isUGC' => true,
                 'isSponsored' => false,
@@ -175,6 +183,7 @@ class LinkTest extends BaseTest
                 'title' => null,
                 'target' => null,
                 'rel' => 'nofollow ugc',
+                'image' => [],
                 'isNofollow' => true,
                 'isUGC' => true,
                 'isSponsored' => false,
@@ -187,6 +196,7 @@ class LinkTest extends BaseTest
                 'title' => null,
                 'target' => null,
                 'rel' => 'noopener',
+                'image' => [],
                 'isNofollow' => false,
                 'isUGC' => false,
                 'isSponsored' => false,
@@ -199,6 +209,7 @@ class LinkTest extends BaseTest
                 'title' => null,
                 'target' => null,
                 'rel' => 'noreferrer',
+                'image' => [],
                 'isNofollow' => false,
                 'isUGC' => false,
                 'isSponsored' => false,
@@ -239,6 +250,7 @@ class LinkTest extends BaseTest
                 'title' => null,
                 'target' => null,
                 'rel' => null,
+                'image' => [],
                 'isNofollow' => false,
                 'isUGC' => false,
                 'isSponsored' => false,
@@ -251,6 +263,7 @@ class LinkTest extends BaseTest
                 'title' => null,
                 'target' => null,
                 'rel' => null,
+                'image' => [],
                 'isNofollow' => false,
                 'isUGC' => false,
                 'isSponsored' => false,
@@ -267,6 +280,71 @@ class LinkTest extends BaseTest
             //     'isUGC' => false,
             //     'isNoopener' => false,
             //     'isNoreferrer' => false,
+            ]
+        ], $web->linksWithDetails);
+    }
+
+    /**
+     * @test
+     */
+    public function testImageUrl()
+    {
+        $web = new \spekulatius\phpscraper();
+
+        // Navigate to the test page.
+        $web->go($this->url . '/links/image-url.html');
+
+        // Check the number of links
+        $this->assertSame(3, count($web->links));
+
+        // Check the complex links list
+        $this->assertSame([
+            [
+                'url' => 'https://placekitten.com/432/287',
+                'text' => '',
+                'title' => null,
+                'target' => null,
+                'rel' => 'nofollow',
+                'image' => [
+                    'https://placekitten.com/432/287'
+                ],
+                'isNofollow' => true,
+                'isUGC' => false,
+                'isSponsored' => false,
+                'isMe' => false,
+                'isNoopener' => false,
+                'isNoreferrer' => false,
+            ], [
+                'url' => 'https://placekitten.com/456/287',
+                'text' => '',
+                'title' => null,
+                'target' => null,
+                'rel' => 'ugc',
+                'image' => [
+                    'https://placekitten.com/456/287',
+                    'https://placekitten.com/456/287'
+                ],
+                'isNofollow' => false,
+                'isUGC' => true,
+                'isSponsored' => false,
+                'isMe' => false,
+                'isNoopener' => false,
+                'isNoreferrer' => false,
+            ], [
+                'url' => 'https://placekitten.com/345/287',
+                'text' => 'This is image',
+                'title' => null,
+                'target' => null,
+                'rel' => 'nofollow ugc',
+                'image' => [
+                    'https://placekitten.com/345/287'
+                ],
+                'isNofollow' => true,
+                'isUGC' => true,
+                'isSponsored' => false,
+                'isMe' => false,
+                'isNoopener' => false,
+                'isNoreferrer' => false,
             ]
         ], $web->linksWithDetails);
     }

--- a/tests/resources/links/image-url.html
+++ b/tests/resources/links/image-url.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Image URL tests</title>
+    </head>
+    <body>
+        <h1>We are testing here!</h1>
+
+        <p>Use img tags as link anchors on this page and check if the img URL is retrieved.</p>
+
+        <h2>Different "rel"-cases</h2>
+        <p><a href="https://placekitten.com/432/287" rel="nofollow"><img src="https://placekitten.com/432/287"></a></p>
+        <p><a href="https://placekitten.com/456/287" rel="ugc"><img src="https://placekitten.com/456/287"><img src="https://placekitten.com/456/287"></a></p>
+        <p><a href="https://placekitten.com/345/287" rel="nofollow ugc"><img src="https://placekitten.com/345/287">This is image</a></p>
+    </body>
+</html>


### PR DESCRIPTION
Resolution of issue #37

Get the URL of the img tag's src attribute when the link's anchor text is an img tag.

## Implementation
The anchor text of a link may have multiple img tags, so it is now retrieved as an array.

## Test
Added tests as implemented.
