### PR TITLE
Expose GoutteClient as an accessible property (#154)

### DIFF
--- a/src/UsesGoutte.php
+++ b/src/UsesGoutte.php
@@ -54,6 +54,16 @@ trait UsesGoutte
     }
 
     /**
+     * Retrieve the client
+     *
+     * @param \Goutte\Client $client
+     */
+    public function client(): GoutteClient
+    {
+        return $this->client;
+    }
+
+    /**
      * Any URL-related methods are in `UsesUrls.php`.
      **/
 


### PR DESCRIPTION
### Updates:

Provide access to the GoutteClient - for any custom needs not wrapped in existing functions. Particularly useful for getting the response of the original request (eg. to get status code)

Example usage:

```
$statusCode = $web->client()->getInternalResponse()->getStatusCode();
```

This was previously requested functionality in https://github.com/spekulatius/PHPScraper/issues/60 and is requested again in https://github.com/spekulatius/PHPScraper/issues/154