### PR TITLE
Handle edge case: "invalid url in base tag"

### DIFF
--- a/src/UsesUrls.php
+++ b/src/UsesUrls.php
@@ -41,7 +41,13 @@ trait UsesUrls
      */
     public function currentBaseHost(): string
     {
-        $uri = Uri::createFromString($this->baseHref() ?? $this->currentUrl());
+        //In case baseHref is a relative URL
+        $currentBase = $this->baseHref();
+        if ($currentBase === null || !preg_match('/^https?:\/\//', $currentBase)) {
+            $currentBase = $this->currentUrl();
+        }
+
+        $uri = Uri::createFromString($currentBase);
 
         return $uri->getScheme() . '://' . $uri->getHost();
     }
@@ -61,7 +67,7 @@ trait UsesUrls
         // Resolve the Url using one of the provided/set base href.
         return (string) UriResolver::resolve(
             Http::createFromString($url),
-            Http::createFromString($baseUrl ?? $this->baseHref() ?? $this->currentBaseHost()),
+            Http::createFromString($baseUrl ?? $this->currentBaseHost()),
         );
     }
 }

--- a/tests/BaseHrefTest.php
+++ b/tests/BaseHrefTest.php
@@ -41,4 +41,18 @@ class BaseHrefTest extends \PHPUnit\Framework\TestCase
             $web->baseHref
         );
     }
+
+    public function testBaseHrefContainRelativePath()
+    {
+        $web = new \Spekulatius\PHPScraper\PHPScraper;
+
+        // Navigate to the test page.
+        // Contains: <base href="/myglasgow/digitalaccessibility/"> (relative path)
+        $web->go('https://www.gla.ac.uk/myglasgow/digitalaccessibility/');
+        // Check the baseHref
+        $this->assertSame(
+            '/myglasgow/digitalaccessibility/',
+            $web->baseHref
+        );
+    }
 }

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -68,6 +68,24 @@ class UrlTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @test
+     */
+    public function testCurrentBaseHostWithBaseIsRelativeUri()
+    {
+        $web = new \Spekulatius\PHPScraper\PHPScraper;
+
+        // Navigate to the test page.
+        // Contains: <base href="/myglasgow/digitalaccessibility/">
+        $web->go('https://www.gla.ac.uk/myglasgow/digitalaccessibility/');
+
+        // Check the base href being passed through the current base host.
+        $this->assertSame(
+            'https://www.gla.ac.uk',
+            $web->currentBaseHost
+        );
+    }
+
+    /**
      * Basic processing of the URLs.
      *
      * @test
@@ -164,6 +182,36 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(
             'http://example.com/index.html',
             $web->makeUrlAbsolute('http://example.com/index.html'),
+        );
+    }
+
+    /**
+     * Special case where the base href is a relative URL. So we need to use the current base host.
+     *
+     * @test
+     */
+    public function testMakeUrlAbsoluteConsiderBaseHrefIsRelativeUrl()
+    {
+        $web = new \Spekulatius\PHPScraper\PHPScraper;
+
+        /**
+         * Navigate to test page: This sets the base URL.
+         *
+         * It contains:
+         *
+         * ```html
+         * <base href="/myglasgow/digitalaccessibility/">
+         * ```
+         *
+         * While it's located on `test-pages.phpscraper.de`.
+         *
+         * This page isn't actually used. It's purely to set the context.
+         */
+        $web->go('https://www.gla.ac.uk/myglasgow/digitalaccessibility/');
+
+        $this->assertSame(
+            'https://www.gla.ac.uk/test/index.html',
+            $web->makeUrlAbsolute('test/index.html'),
         );
     }
 


### PR DESCRIPTION
### Add test and bugfix in case the href content of 'base' tag is a relative url.

The bug have been encounter on the url : https://www.gla.ac.uk/myglasgow/digitalaccessibility/

the current base tag contain : `<base href="/myglasgow/digitalaccessibility/" />`

![image](https://user-images.githubusercontent.com/18738120/232734020-d85f9ca4-4a1a-4e92-ae58-25cf3a4dafee.png)


### Stack Trace and error message: 

```
string(193) "The URL of the element is relative, so you must define its base URI passing an absolute URL to the constructor of the "Symfony\Component\DomCrawler\AbstractUriElement" class ("://" was passed)."

#0 /srv/app/vendor/spekulatius/phpscraper/src/UsesContent.php(492): Symfony\Component\DomCrawler\AbstractUriElement->__construct(Object(DOMElement), '://')
#1 /srv/app/vendor/spekulatius/phpscraper/src/PHPScraper.php(138): Spekulatius\PHPScraper\Core->linksWithDetails()
#2 /srv/app/src/Services/ScraperService.php(107): Spekulatius\PHPScraper\PHPScraper->__call('linksWithDetail...', Array)
#3 /srv/app/src/Services/AnalyzerService.php(56): App\Services\ScraperService->extractData(Object(Spekulatius\PHPScraper\PHPScraper))
#4 /srv/app/src/Services/AnalyzerService.php(28): App\Services\AnalyzerService->extractDataFromUrl('https://www.gla...', 'en', 'uk')
#5 /srv/app/src/Controller/HomeController.php(80): App\Services\AnalyzerService->analyzeUrl('https://www.gla...', Object(App\Entity\Language), 'uk')
#6 /srv/app/vendor/symfony/http-kernel/HttpKernel.php(163): App\Controller\HomeController->index(Object(Symfony\Component\HttpFoundation\Request))
#7 /srv/app/vendor/symfony/http-kernel/HttpKernel.php(74): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#8 /srv/app/vendor/symfony/http-kernel/Kernel.php(184): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#9 /srv/app/vendor/symfony/runtime/Runner/Symfony/HttpKernelRunner.php(35): Symfony\Component\HttpKernel\Kernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#10 /srv/app/vendor/autoload_runtime.php(29): Symfony\Component\Runtime\Runner\Symfony\HttpKernelRunner->run()
#11 /srv/app/public/index.php(5): require_once('/srv/app/vendor...')
#12 {main}"
```

Is that possible for you to generate an url with an invalid base tag, that i can use instead of those of Glasgow University, please ?

Regards,
Pierrick