### PR TITLE
added phpstan in github actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,7 @@ name: Tests
 on: [pull_request]
 
 jobs:
+  ## PHPUNIT
   phpunit:
     runs-on: ubuntu-latest
     strategy:
@@ -18,3 +19,25 @@ jobs:
       - run: php -v
       - run: composer update ${{ matrix.composer-flags }} --no-interaction --no-progress --prefer-dist --ansi
       - run: ./vendor/bin/phpunit --color=always
+
+  ## PHPSTAN
+  phpstan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@2.21.0
+        with:
+          php-version: '8.0'
+          coverage: none
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          update: true
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress --optimize-autoloader
+
+      - name: PHPStan tests
+        run: composer phpstan

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ websites/.yarnrc.yml
 .vscode
 .history
 .notes
+.tmp

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/thanks": "^1.0.0",
         "phpunit/phpunit": "^8.0.0|^9.0.0",
         "illuminate/collections": "^8.0.0|^9.0.0",
-        "phpstan/phpstan": "^1.9"
+        "phpstan/phpstan": "^1.10"
     },
     "autoload": {
         "psr-4": {
@@ -45,7 +45,8 @@
     },
     "scripts": {
         "test": "./vendor/phpunit/phpunit/phpunit --cache-result --cache-result-file=/tmp --order-by=defects --colors=always --stop-on-failure",
-        "ct": "while true; do composer run test; sleep 30; done"
+        "ct": "while true; do composer run test; sleep 30; done",
+        "phpstan": "vendor/bin/phpstan -v"
     },
     "funding": [
         {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+parameters:
+  level: 3
+  paths:
+    - src
+  excludePaths:
+    - vendor
+  tmpDir: .tmp


### PR DESCRIPTION
i saw there is phpstan, but not configured for github actions. Maybe you like it otherwise close the PR. 

If we increase to phpstan level 4 you'll get a https://phpstan.org/blog/bring-your-exceptions-under-control#dead-catch-reporting-in-bleeding-edge.

in order to test local use `composer phpstan`