### PR TITLE
Fix HTTPClient config

### DIFF
--- a/src/PHPScraper.php
+++ b/src/PHPScraper.php
@@ -98,8 +98,8 @@ class PHPScraper
         $httpClient = SymfonyHttpClient::create([
             'proxy' => $this->config['proxy'],
             'timeout' => $this->config['timeout'],
-            'verify_host' => $this->config['disable_ssl'],
-            'verify_peer' => $this->config['disable_ssl'],
+            'verify_host' => !$this->config['disable_ssl'],
+            'verify_peer' => !$this->config['disable_ssl'],
         ]);
 
         // BrowserKit Client and set some config needed for it.


### PR DESCRIPTION
This is the unplanned contribution 🙃 

`verify_host` should be the opposite of `disable_ssl`.

https://symfony.com/doc/current/reference/configuration/framework.html#verify-host

Please consider https://github.com/spekulatius/PHPScraper/pull/192#discussion_r1306719137
