### PR TITLE
Upgrade from league/uri 6.x to league/uri 7.x, replacing deprecated function uses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-intl": "*",
         "symfony/dom-crawler": "^5.4 || ^6.0",
         "donatello-za/rake-php-plus": "^1.0.15",
-        "league/uri": "^6.0",
+        "league/uri": "^7.0",
         "symfony/browser-kit": "^6.0",
         "symfony/http-client": "^6.0",
         "symfony/css-selector": "^6.0"

--- a/src/UsesContent.php
+++ b/src/UsesContent.php
@@ -448,7 +448,7 @@ trait UsesContent
         return array_values(array_filter(
             $this->links(),
             function ($link) use (&$currentRootDomain): bool {
-                $linkRootDomain = Uri::createFromString($link)->getHost();
+                $linkRootDomain = Uri::new($link)->getHost();
 
                 return $currentRootDomain === $linkRootDomain;
             }

--- a/src/UsesUrls.php
+++ b/src/UsesUrls.php
@@ -32,7 +32,7 @@ trait UsesUrls
      */
     public function currentHost(): ?string
     {
-        return Uri::createFromString($this->currentUrl())->getHost();
+        return Uri::new($this->currentUrl())->getHost();
     }
 
     /**
@@ -42,7 +42,7 @@ trait UsesUrls
      */
     public function currentBaseHost(): string
     {
-        $uri = Uri::createFromString($this->baseHref() ?? $this->currentUrl());
+        $uri = Uri::new($this->baseHref() ?? $this->currentUrl());
 
         return $uri->getScheme() . '://' . $uri->getHost();
     }
@@ -61,8 +61,8 @@ trait UsesUrls
 
         // Resolve the Url using one of the provided/set base href.
         return (string) UriResolver::resolve(
-            Http::createFromString($url),
-            Http::createFromString($baseUrl ?? $this->baseHref() ?? $this->currentBaseHost()),
+            Http::new($url),
+            Http::new($baseUrl ?? $this->baseHref() ?? $this->currentBaseHost()),
         );
     }
 }


### PR DESCRIPTION
Reviewed all uses of league/uri and followed https://uri.thephpleague.com/uri/7.0/upgrading/ to upgrade deprecated functions to their new equivalent method names